### PR TITLE
Add godotalgorithm as a maintainer of mopac

### DIFF
--- a/recipes/mopac/meta.yaml
+++ b/recipes/mopac/meta.yaml
@@ -58,3 +58,4 @@ about:
 extra:
   recipe-maintainers:
     - awvwgk
+    - godotalgorithm


### PR DESCRIPTION
I see that you have just created a pull request for a MOPAC recipe in conda-forge. Coincidentally, that was my top priority after making the latest MOPAC patch release yesterday. It seems like you have saved me quite a bit of trouble, although the relative terseness of the recipe suggests that there weren't too many problems beyond the mopac-bz issue that you submitted a PR for to MOPAC earlier today.

I am interested in being added as a maintainer of this recipe, as my intention has been to support conda-forge as the primary package manager for MOPAC distribution beyond its stand-alone installer.
